### PR TITLE
Add support for extracting custom claims from JWT access tokens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-auth0-authbackend"
-version = "0.2.0"
+version = "0.3.0"
 description = "Auth0 Authentication Backend for Django"
 authors = [{name = "Andy Reagan", email = "andy@andyreagan.com"}]
 license = "MIT"


### PR DESCRIPTION
Add ACCESS_TOKEN_CLAIM_MAPPING and get_extra_defaults() hook to allow extracting custom claims from JWT access tokens and mapping them to user model fields. This enables use cases like syncing member_id or other custom claims that are only available in the access token.