### PR TITLE
Enable E2E tests to run on pull requests

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -44,8 +44,8 @@ jobs:
   functional-tests:
     name: Functional Tests (E2E)
     runs-on: ubuntu-latest
-    # Only run functional tests if Auth0 credentials are available
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    # Run functional tests on pushes to main/tags and on pull requests
+    # Note: Secrets are only available for PRs from the same repo, not forks
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]


### PR DESCRIPTION
Remove the condition that restricted functional tests to only run on pushes to main/tags. Now E2E tests will run on all branches and PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)